### PR TITLE
chore: add husky git hooks for branch naming and commit message valid…

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+  node .husky/validate-commit-msg.js "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+node .husky/validate-branch-name.js

--- a/.husky/validate-branch-name.js
+++ b/.husky/validate-branch-name.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+const { execSync } = require("child_process");
+
+// Get current branch name
+let currentBranch;
+try {
+  currentBranch = execSync("git branch --show-current", {
+    encoding: "utf-8",
+  }).trim();
+} catch (error) {
+  console.error("Error: Could not determine current branch");
+  process.exit(1);
+}
+
+// Protected branches that should never be committed to directly
+const protectedBranches = ["main", "develop"];
+
+if (protectedBranches.includes(currentBranch)) {
+  console.error(
+    "\nError: Direct commits to protected branches are not allowed!\n",
+  );
+  console.error(`You are trying to commit to: ${currentBranch}`);
+  console.error("Protected branches: main, develop\n");
+  console.error("Please create a feature branch instead:");
+  console.error("  git checkout develop");
+  console.error("  git checkout -b feature/your-feature-name\n");
+  process.exit(1);
+}
+
+// Valid branch name pattern
+const branchPattern = /^(feature|bugfix|chore|release)\/[a-z0-9-]+$/;
+
+if (!branchPattern.test(currentBranch)) {
+  console.error("\nError: Invalid branch name format!\n");
+  console.error(`Current branch: ${currentBranch}`);
+  console.error("Branch name must follow the pattern: <type>/<description>\n");
+  console.error("Valid types:");
+  console.error("  - feature/  : New features or enhancements");
+  console.error("  - bugfix/   : Bug fixes and corrections");
+  console.error("  - chore/    : Maintenance, dependencies, refactoring");
+  console.error("  - release/  : Release preparation branches\n");
+  console.error("Rules:");
+  console.error("  - Use lowercase");
+  console.error("  - Use hyphens to separate words");
+  console.error("  - No spaces or special characters\n");
+  console.error("Examples:");
+  console.error("  feature/user-authentication");
+  console.error("  bugfix/login-validation");
+  console.error("  chore/update-dependencies\n");
+  process.exit(1);
+}
+
+console.log("Branch name is valid");
+process.exit(0);

--- a/.husky/validate-commit-msg.js
+++ b/.husky/validate-commit-msg.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+// Read the commit message
+const commitMsgFile = process.argv[2] || ".git/COMMIT_EDITMSG";
+const commitMsg = fs.readFileSync(commitMsgFile, "utf-8").trim();
+
+// Conventional commit pattern
+const conventionalCommitPattern =
+  /^(feat|fix|chore|refactor|docs|test|ci):\s.{1,72}$/;
+
+// Check if commit message matches pattern
+if (!conventionalCommitPattern.test(commitMsg)) {
+  console.error("\nInvalid commit message format!\n");
+  console.error("Commit message must follow conventional commits format:");
+  console.error("  <type>: <description>\n");
+  console.error("Valid types: feat, fix, chore, refactor, docs, test, ci");
+  console.error("Rules:");
+  console.error("  - Use imperative mood (add not added)");
+  console.error("  - Start with lowercase after type");
+  console.error("  - No period at the end");
+  console.error("  - Maximum 72 characters\n");
+  console.error("Examples:");
+  console.error("  feat: implement user registration endpoint");
+  console.error("  fix: resolve login token expiry issue");
+  console.error("  chore: update FastAPI dependencies\n");
+  console.error(`Your message: "${commitMsg}"\n`);
+  process.exit(1);
+}
+
+console.log("Commit message is valid");
+process.exit(0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "full-sms",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "full-sms",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "husky": "^9.1.7"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "full-sms",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepare": "husky"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/COS301-SE-2026/Full-SMS.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/COS301-SE-2026/Full-SMS/issues"
+  },
+  "homepage": "https://github.com/COS301-SE-2026/Full-SMS#readme",
+  "description": "",
+  "devDependencies": {
+    "husky": "^9.1.7"
+  }
+}


### PR DESCRIPTION
Implement automated Git hooks to enforce the project branching strategy and commit message conventions defined in our team workflow guidelines.

Changes made
  - Install Husky as a dev dependency at project root
  - Create commit-msg hook to validate conventional commit format
  - Create pre-commit hook to validate branch naming conventions
  - Add validation script for commit messages supporting types: feat, fix, chore, refactor, docs, test, ci
  - Add validation script for branch names requiring prefixes: feature/, bugfix/, chore/, release/
  - Block direct commits to protected branches: main and develop
 
Test cases
- test 1: Valid commit message on valid branch succeeds
  - Test 2: Invalid commit message format is rejected with helpful error message
  - Test 3: Invalid branch name format is rejected with pattern examples
  - Test 4: Direct commits to main or develop branches are blocked
  - Test 5: All validation scripts are executable and run automatically on commit