### PR TITLE
merge feature/file-upload to develop

### DIFF
--- a/api/controllers/upload_controller.py
+++ b/api/controllers/upload_controller.py
@@ -2,7 +2,7 @@ from fastapi import UploadFile, HTTPException
 from pathlib import Path
 from api.services.upload_service import save_temp_file, get_file_size
 
-ALLOWED_EXTENSIONS = {".pt3", ".csv"}
+ALLOWED_EXTENSIONS = {".pt3", ".csv", ".h5", ".hdf5"}
 
 async def handle_upload(file: UploadFile) -> dict:
     # 1. Validate file extension

--- a/api/tests/test_upload.py
+++ b/api/tests/test_upload.py
@@ -26,6 +26,15 @@ def test_upload_valid_csv():
     assert response.status_code == 200
     assert response.json()["filename"] == "data.csv"
 
+def test_upload_valid_h5():
+    fake_file = io.BytesIO(b"fake h5 content")
+    response = client.post(
+        "/upload/",
+        files={"file": ("data.h5", fake_file, "application/octet-stream")}
+    )
+    assert response.status_code == 200
+    assert response.json()["filename"] == "data.h5"
+    
 def test_upload_invalid_extension():
     fake_file = io.BytesIO(b"some content")
     response = client.post(

--- a/api/tests/test_upload.py
+++ b/api/tests/test_upload.py
@@ -34,7 +34,16 @@ def test_upload_valid_h5():
     )
     assert response.status_code == 200
     assert response.json()["filename"] == "data.h5"
-    
+
+def test_upload_valid_hdf5():
+    fake_file = io.BytesIO(b"fake hdf5 content")
+    response = client.post(
+        "/upload/",
+        files={"file": ("data.hdf5", fake_file, "application/octet-stream")}
+    )
+    assert response.status_code == 200
+    assert response.json()["filename"] == "data.hdf5"
+
 def test_upload_invalid_extension():
     fake_file = io.BytesIO(b"some content")
     response = client.post(

--- a/api/tests/test_upload_controller.py
+++ b/api/tests/test_upload_controller.py
@@ -32,6 +32,15 @@ async def test_valid_h5_upload():
     
     assert result["status"] == "pending"
     assert result["filename"] == "data.h5"
+
+@pytest.mark.asyncio
+async def test_valid_hdf5_upload():
+    fake_file = UploadFile(filename="data.hdf5", file=io.BytesIO(b"fake hdf5 content"))
+    
+    result = await handle_upload(fake_file)
+    
+    assert result["status"] == "pending"
+    assert result["filename"] == "data.hdf5"
     
 @pytest.mark.asyncio
 async def test_invalid_extension_pdf():

--- a/api/tests/test_upload_controller.py
+++ b/api/tests/test_upload_controller.py
@@ -25,6 +25,15 @@ async def test_valid_csv_upload():
     assert result["filename"] == "data.csv"
 
 @pytest.mark.asyncio
+async def test_valid_h5_upload():
+    fake_file = UploadFile(filename="data.h5", file=io.BytesIO(b"fake h5 content"))
+    
+    result = await handle_upload(fake_file)
+    
+    assert result["status"] == "pending"
+    assert result["filename"] == "data.h5"
+    
+@pytest.mark.asyncio
 async def test_invalid_extension_pdf():
     fake_file = UploadFile(filename="report.pdf", file=io.BytesIO(b"pdf content"))
     


### PR DESCRIPTION
Issue/Feature: 
A feature that allows .h5 and .hdf5 to be in the list of allowed file extensions

Changes Made:
- I added .h5 and .hdf5 in the list of allowed file extensions
- I also added test cases to test the success of an .h5 or .hdf5 file upload
- 
Test Cases:
Test 1: User can upload a valid .h5 file and the system responds with a "200" status code
Test 2: User can upload a valid .hdf5 file and the system responds with a "200" status code.

Related Issues:
Closes #45, #46, #47, #48, #49 and #50